### PR TITLE
LTC improvements

### DIFF
--- a/prevalence.R
+++ b/prevalence.R
@@ -83,8 +83,7 @@ months <- tibble(
 ltc_invite_census <- inner_join(
   ltc_invite,
   months,
-  by = join_by(within(
-    ltc_invite_date,
+  by = join_by(between(
     ltc_invite_date,
     census_date_minus15,
     census_date
@@ -114,8 +113,7 @@ ltc_invite_attend_census <- left_join(
 ltc_attend_census <- inner_join(
   ltc_attend,
   months,
-  by = join_by(within(
-    ltc_attend_date,
+  by = join_by(between(
     ltc_attend_date,
     census_date_minus15,
     census_date

--- a/prevalence.R
+++ b/prevalence.R
@@ -80,7 +80,7 @@ months <- tibble(
   census_date_minus15 = census_date - months(15)
 )
 
-ltc_invite_census <- left_join(
+ltc_invite_census <- inner_join(
   ltc_invite,
   months,
   by = join_by(within(
@@ -111,7 +111,7 @@ ltc_invite_attend_census <- left_join(
 ) |>
   select(PatientID, PracticeID, census_date, ltc_invite_date, ltc_attend_date)
 
-ltc_attend_census <- left_join(
+ltc_attend_census <- inner_join(
   ltc_attend,
   months,
   by = join_by(within(
@@ -125,7 +125,7 @@ ltc_attend_census <- left_join(
   select(PatientID, PracticeID, census_date, ltc_attend_date) |>
   distinct(.keep_all = TRUE)
 
-first_diag_census <- left_join(
+first_diag_census <- inner_join(
   first_diag,
   months,
   # Join on condition that FirstDiag is before or on census_date


### PR DESCRIPTION
This pull request updates the way patient invite, attend, and diagnosis records are joined with census months in the `prevalence.R` file. The main change is switching from a left join to an inner join for these operations, which means only records with matching dates in both tables will be included in the results. This will likely reduce the number of rows in the output and ensure that only relevant records are considered.

**Join logic updates:**

* Changed `ltc_invite_census`, `ltc_attend_census`, and `first_diag_census` from using `left_join` to `inner_join` with the `months` table, ensuring only records with matching date ranges are included. [[1]](diffhunk://#diff-426c62eefd5fc91058160a8ea00852c8cd5a64f199e987b7c79e0fd77f7e7f61L83-R86) [[2]](diffhunk://#diff-426c62eefd5fc91058160a8ea00852c8cd5a64f199e987b7c79e0fd77f7e7f61L114-R116) [[3]](diffhunk://#diff-426c62eefd5fc91058160a8ea00852c8cd5a64f199e987b7c79e0fd77f7e7f61L128-R126)

**Join condition refinement:**

* Updated the join condition from `within` to `between` for the date range logic, making the join criteria more explicit and likely improving clarity and correctness. [[1]](diffhunk://#diff-426c62eefd5fc91058160a8ea00852c8cd5a64f199e987b7c79e0fd77f7e7f61L83-R86) [[2]](diffhunk://#diff-426c62eefd5fc91058160a8ea00852c8cd5a64f199e987b7c79e0fd77f7e7f61L114-R116)