### PR TITLE
Update to July data - Especially pharma

### DIFF
--- a/00_data_prep_ltc.R
+++ b/00_data_prep_ltc.R
@@ -93,7 +93,7 @@ cleaned_filtered_data <- cleaned_data |>
 
 write_parquet(
   cleaned_filtered_data,
-  path(dir, "data", "working", "june_25_clean_data_w_resolved.parquet"), # will need to update every time a new extract
+  path(dir, "data", "working", "july_25_clean_data_w_resolved.parquet"), # will need to update every time a new extract
   compression = "zstd"
 )
 

--- a/00_data_prep_pharma.R
+++ b/00_data_prep_pharma.R
@@ -58,7 +58,7 @@ raw_data <- unzip(zipfile = data_file_path, exdir = tempdir())[1] |>
 # Write out cleaned data
 write_parquet(
   raw_data,
-  path(dir, "data", "working", "june_25_pharmacotherapy.parquet"),
+  path(dir, "data", "working", "july_25_pharmacotherapy.parquet"),
   compression = "zstd"
 )
 

--- a/Shetland_PCPIP_Indicators.Rmd
+++ b/Shetland_PCPIP_Indicators.Rmd
@@ -3,7 +3,7 @@ title: "Shetland PCPIP Indicators"
 author: "LIST (Local Intelligence Support Team) - Public Health Scotland"
 date: "Updated: `r format(Sys.Date(), '%d %B %Y')`"
 params:
-  data_date: "June 2025"
+  data_date: "July 2025"
 output:
   html_document:
     css: phs_style.css

--- a/Shetland_PCPIP_Indicators.Rmd
+++ b/Shetland_PCPIP_Indicators.Rmd
@@ -14,7 +14,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE, fig.align = 'center', out.width = '100%')
+knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE, fig.align = "center", out.width = "100%")
 
 # Copy in the PHS style CSS file if required
 if (!file.exists(file.path(getwd(), "phs_style.css"))) {
@@ -57,13 +57,13 @@ all_data <- monthly_summary |>
     relationship = "one-to-one"
   ) |>
   left_join(
-    quarterly_event_type |> 
+    quarterly_event_type |>
       pivot_wider(
         id_cols = c(PracticeID, quarter_start),
-        names_from = DerivedEventType, 
-        values_from = event_type_proportion, 
+        names_from = DerivedEventType,
+        values_from = event_type_proportion,
         values_fill = 0.0
-        ),
+      ),
     by = join_by(census_date == quarter_start, PracticeID),
     relationship = "one-to-one"
   ) |>
@@ -77,7 +77,7 @@ all_data <- monthly_summary |>
     census_date = as.Date(census_date),
     PracticeID = factor(PracticeID, levels = unique(PracticeID)),
     across(where(is.numeric), \(x) replace_na(x, 0))
-    ) 
+  )
 
 practice_ids <- unique(sort(all_data[["PracticeID"]]))
 n_practices <- length(practice_ids)
@@ -344,7 +344,8 @@ cv_ctac_3_plotly <- plot_ly(
     "Practice:", PracticeID,
     "<br>Month:", census_date,
     "<br>Invites sent:", ltc_first_invite_count,
-    "<br>Attend percentage:", percent(ltc_first_invite_attend_prop, accuracy = 0.1))
+    "<br>Attend percentage:", percent(ltc_first_invite_attend_prop, accuracy = 0.1)
+  )
 ) |>
   layout(
     title = str_wrap("Monthly CV attendances within 60 days of first invite", 25),
@@ -400,7 +401,8 @@ cv_ctac_4_plotly <- plot_ly(
     "Practice:", PracticeID,
     "<br>Month:", census_date,
     "<br>First attendances (in the last 15 months):", ltc_first_attend_count,
-    "<br>HoC sent percentage:", percent(ltc_first_attend_hoc_sent_prop, accuracy = 0.1))
+    "<br>HoC sent percentage:", percent(ltc_first_attend_hoc_sent_prop, accuracy = 0.1)
+  )
 ) |>
   layout(
     title = str_wrap("Monthly HoC letters sent within 30 days of first attendance (last 15 months of attendances)", 25),
@@ -499,9 +501,9 @@ subplot_title_annotations <- create_subplot_title_annotations(
 )
 
 event_type_colours <- setNames(
-  object = c("#12436D", "#28A197", "#801650"), 
-  nm =  unique(pull(quarterly_event_type, DerivedEventType))
-  )
+  object = c("#12436D", "#28A197", "#801650"),
+  nm = unique(pull(quarterly_event_type, DerivedEventType))
+)
 
 pharm_9_plotly <- quarterly_event_type |>
   group_by(PracticeID) %>%
@@ -599,7 +601,7 @@ Note that in this iteration, the below data table includes blank rows for months
 # Create the DT datatable
 pharm_9_dt <- make_dt(
   shared_data = shared_monthly_summary,
-  var = c("Medication Review with Person",  "Notes based Medication Review", "Polypharmacy Medication Review"),
+  var = c("Medication Review with Person", "Notes based Medication Review", "Polypharmacy Medication Review"),
   keep_cols = "DerivedEventType",
   percentage = TRUE
 )
@@ -729,3 +731,4 @@ for (sheet_name in names(all_data_frames)) {
 # Save the workbook to the specified path
 file_path <- paste0("/conf/LIST_analytics/Shetland/Primary Care/LTC/data/outputs/Indicators_", params$data_date, ".xlsx")
 saveWorkbook(wb, file_path, overwrite = TRUE)
+```

--- a/pharma.R
+++ b/pharma.R
@@ -8,7 +8,7 @@ dir <- path("/conf/LIST_analytics/Shetland/Primary Care/LTC")
 
 # Read in pre-cleaned data
 med_reviews <- read_parquet(
-  path(dir, "data", "working", "june_25_pharmacotherapy.parquet")
+  path(dir, "data", "working", "july_25_pharmacotherapy.parquet")
 )
 
 # Summarise events by staff type and month, filter for Pharmacist

--- a/pharma1.R
+++ b/pharma1.R
@@ -9,14 +9,14 @@ dir <- path("/conf/LIST_analytics/Shetland/Primary Care/LTC")
 
 # Read in pre-cleaned data
 med_reviews <- read_parquet(
-  path(dir, "data", "working", "june_25_pharmacotherapy.parquet")
+  path(dir, "data", "working", "july_25_pharmacotherapy.parquet")
 )
 
 # Create monthly census dates
 months <- tibble(
   census_date = seq.Date(
     from = as.Date("2000-01-01"),
-    to = as.Date("2025-08-01"),
+    to = as.Date("2025-07-01"),
     by = "month"
   )
 ) |>

--- a/prevalence.R
+++ b/prevalence.R
@@ -10,7 +10,7 @@ library(dtplyr)
 dir <- path("/conf/LIST_analytics/Shetland/Primary Care/LTC")
 
 clean_data <- read_parquet(
-  path(dir, "data", "working", "june_25_clean_data_w_resolved.parquet")
+  path(dir, "data", "working", "july_25_clean_data_w_resolved.parquet")
 )
 
 # Find the first diagnosis date (any condition) for each patient


### PR DESCRIPTION
This pull request updates the data extracts and references throughout the codebase to use the July 2025 datasets instead of June 2025. It also includes minor formatting improvements and a small correction to the date range in one script.

**Data Extract Updates:**

* Updated all references to cleaned and pharmacotherapy data files from `june_25_*` to `july_25_*` in `00_data_prep_ltc.R`, `00_data_prep_pharma.R`, `pharma.R`, `pharma1.R`, and `prevalence.R`. [[1]](diffhunk://#diff-c993e172e831ba0103b4ff821109ec9e1c2ef2c0d0f9da28c3c12c2a8120b6ffL96-R96) [[2]](diffhunk://#diff-89c6ec318aae337a56ddb5678fa80090d56ea6941da96a546069d06fae5ebb9bL61-R61) [[3]](diffhunk://#diff-d1b8107a0c6c72fc0c50d7cde368d4ed3bfaaf7966e68b6d15e4d10f6d161523L11-R11) [[4]](diffhunk://#diff-54d5054deb4bdc890c96eb75e2902e07bf9df7fe7cdf781971425352b6a94003L12-R19) [[5]](diffhunk://#diff-426c62eefd5fc91058160a8ea00852c8cd5a64f199e987b7c79e0fd77f7e7f61L13-R13)

**Report and Output Updates:**

* Changed the `data_date` parameter in `Shetland_PCPIP_Indicators.Rmd` from "June 2025" to "July 2025" to reflect the new reporting period.
* Updated the output Excel file name in `Shetland_PCPIP_Indicators.Rmd` to use the new `data_date` parameter.

**Formatting Improvements:**

* Standardized quotation marks in code chunks within `Shetland_PCPIP_Indicators.Rmd` for consistency.
* Fixed the placement of closing parentheses in `plot_ly` calls for improved readability and correctness. [[1]](diffhunk://#diff-fd3877e4c30fd37f631279a28d809c13a9a6510b967d9f5a3c1cc47b6edaa37fL355-R356) [[2]](diffhunk://#diff-fd3877e4c30fd37f631279a28d809c13a9a6510b967d9f5a3c1cc47b6edaa37fL413-R415)

**Date Range Correction:**

* Adjusted the end date for monthly census dates in `pharma1.R` from August 2025 to July 2025 to match the new extract period.